### PR TITLE
fix: lock 관심사 분리

### DIFF
--- a/src/main/java/io/hhplus/tdd/point/service/PointService.java
+++ b/src/main/java/io/hhplus/tdd/point/service/PointService.java
@@ -1,13 +1,12 @@
 package io.hhplus.tdd.point.service;
 
-import io.hhplus.tdd.point.domain.PointHistory;
-import io.hhplus.tdd.point.value.TransactionType;
-import io.hhplus.tdd.point.domain.UserPoint;
-import io.hhplus.tdd.point.concurrent.PointLock;
 import io.hhplus.tdd.point.concurrent.PointLockManager;
 import io.hhplus.tdd.point.constraint.PointValidator;
+import io.hhplus.tdd.point.domain.PointHistory;
+import io.hhplus.tdd.point.domain.UserPoint;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
+import io.hhplus.tdd.point.value.TransactionType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,39 +24,25 @@ public class PointService {
     private final PointLockManager lockManager;
 
     public UserPoint chargePoint(long id, long amount) {
-        String lockKey = "point-" + id;
-        PointLock pointLock = lockManager.getLock(lockKey);
-        pointLock.lock();
-        try {
-            // 충전 정책 체크
-            pointValidator.chargePointCheck(amount);
+        pointValidator.chargePointCheck(amount);
+        String lockId = "point-" + id;
+        return lockManager.executeWithLock(lockId, () -> {
             pointHistoryRepository.createPointHistory(id, amount, TransactionType.CHARGE, System.currentTimeMillis());
 
             UserPoint userPoint = userPointRepository.getUserPoint(id);
             return userPointRepository.createOrUpdate(id, userPoint.point() + amount);
-        } finally {
-            if (pointLock.isHeldByCurrentThread()) {
-                pointLock.unlock();
-            }
-        }
+        });
     }
 
     public UserPoint usePoint(long id, long amount) {
-        String lockKey = "point-" + id;
-        PointLock pointLock = lockManager.getLock(lockKey);
-        pointLock.lock();
-        try {
+        // 사용 정책 체크
+        String lockId = "point-" + id;
+        return lockManager.executeWithLock(lockId, () -> {
             UserPoint userPoint = userPointRepository.getUserPoint(id);
-            // 사용 정책 체크
             pointValidator.usePointCheck(amount, userPoint.point());
             pointHistoryRepository.createPointHistory(id, amount, TransactionType.USE, System.currentTimeMillis());
             return userPointRepository.createOrUpdate(id, userPoint.point() - amount);
-        } finally {
-            if (pointLock.isHeldByCurrentThread()) {
-                pointLock.unlock();
-            }
-        }
-
+        });
     }
 
     public UserPoint getUserPoint(long id) {

--- a/src/test/java/io/hhplus/tdd/point/service/unit/PointUseTest.java
+++ b/src/test/java/io/hhplus/tdd/point/service/unit/PointUseTest.java
@@ -1,21 +1,22 @@
 package io.hhplus.tdd.point.service.unit;
 
-import io.hhplus.tdd.point.value.TransactionType;
-import io.hhplus.tdd.point.domain.UserPoint;
-import io.hhplus.tdd.point.concurrent.PointLock;
 import io.hhplus.tdd.point.concurrent.PointLockManager;
 import io.hhplus.tdd.point.constraint.PointValidator;
+import io.hhplus.tdd.point.domain.UserPoint;
 import io.hhplus.tdd.point.exception.PointErrorCode;
 import io.hhplus.tdd.point.exception.PointException;
 import io.hhplus.tdd.point.repository.PointHistoryRepository;
 import io.hhplus.tdd.point.repository.UserPointRepository;
 import io.hhplus.tdd.point.service.PointService;
+import io.hhplus.tdd.point.value.TransactionType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -41,9 +42,6 @@ class PointUseTest {
     private PointValidator pointValidator;
 
     @Mock
-    private PointLock pointLock;
-
-    @Mock
     private PointLockManager lockManager;
 
     @InjectMocks
@@ -57,8 +55,11 @@ class PointUseTest {
         long currentPoint = 50;
 
         // lock 모킹
-        when(lockManager.getLock(anyString())).thenReturn(pointLock);
-        doNothing().when(pointLock).lock();
+        when(lockManager.executeWithLock(anyString(), any()))
+                .thenAnswer(answer -> {
+                    Supplier<UserPoint> action = answer.getArgument(1);
+                    return action.get();
+                });
 
         when(userPointRepository.getUserPoint(userId))
                 .thenReturn(new UserPoint(userId, currentPoint, System.currentTimeMillis()));
@@ -84,8 +85,11 @@ class PointUseTest {
         long negativeAmount = -10;
 
         // lock 모킹
-        when(lockManager.getLock(anyString())).thenReturn(pointLock);
-        doNothing().when(pointLock).lock();
+        when(lockManager.executeWithLock(anyString(), any()))
+                .thenAnswer(answer -> {
+                    Supplier<UserPoint> action = answer.getArgument(1);
+                    return action.get();
+                });
 
         when(userPointRepository.getUserPoint(userId))
                 .thenReturn(new UserPoint(userId, currentPoint, System.currentTimeMillis()));
@@ -111,8 +115,11 @@ class PointUseTest {
         long remainPoint = 300;
 
         // lock 모킹
-        when(lockManager.getLock(anyString())).thenReturn(pointLock);
-        doNothing().when(pointLock).lock();
+        when(lockManager.executeWithLock(anyString(), any()))
+                .thenAnswer(answer -> {
+                    Supplier<UserPoint> action = answer.getArgument(1);
+                    return action.get();
+                });
 
         when(userPointRepository.getUserPoint(userId))
                 .thenReturn(new UserPoint(userId, currentPoint, System.currentTimeMillis()));
@@ -135,8 +142,11 @@ class PointUseTest {
         long remainPoint = 300;
 
         // lock 모킹
-        when(lockManager.getLock(anyString())).thenReturn(pointLock);
-        doNothing().when(pointLock).lock();
+        when(lockManager.executeWithLock(anyString(), any()))
+                .thenAnswer(answer -> {
+                    Supplier<UserPoint> action = answer.getArgument(1);
+                    return action.get();
+                });
 
         when(userPointRepository.getUserPoint(userId))
                 .thenReturn(new UserPoint(userId, currentPoint, System.currentTimeMillis()));


### PR DESCRIPTION
## 변경사항

* AS-IS: lockManager에서 getLock을 통해 lock을 생성하고 반환하여 pointService에서 락을 관리 및 사용하고 있다.
* TO-BE: lockManager에서 executeWithLock에 lockId와 락을 걸어야 하는 로직(action)을 받아서 lockManager에서만 락을 관리, 사용